### PR TITLE
Remind users to search closed issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/ckan_bug.yml
+++ b/.github/ISSUE_TEMPLATE/ckan_bug.yml
@@ -13,7 +13,9 @@ body:
     id: checked-issues
     attributes:
       label: Is there an existing issue for this?
-      description: Please search to see if an issue already exists for the bug you encountered.
+      description: |
+        Please search to see if an issue already exists for the bug you encountered,
+        including closed issues in case it's something we have already investigated.
       options:
         - label: I have searched the existing issues
           required: true


### PR DESCRIPTION
## Motivation

While working on KSP-CKAN/NetKAN#9734, I noticed that all of the duplicate issue reports had the "I have searched the existing issues" checkbox checked, which is supposed to prevent duplicates.

## Cause

The first issue was closed because this isn't a problem with CKAN or that CKAN can fix. If people were in fact searching the existing issues, I speculate that they missed it (and the previous duplicates) because they only searched open issues.

## Changes

Now the description of the checkbox reminds users to search closed issues as well. Hopefully this will further limit duplicates.
