### PR TITLE
Direct users to the proper place to report TweakScale bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/ckan_bug.yml
+++ b/.github/ISSUE_TEMPLATE/ckan_bug.yml
@@ -6,6 +6,9 @@ body:
   - type: markdown
     attributes:
       value: |
+        NOTE: Issues with TweakScale that do not relate to how mods are
+        installed should be reported on the TweakScale bug tracker here:
+        https://github.com/TweakScale/TweakScale/issues
         NOTE: If you are using the CKAN accelerator service in China, please report issues here instead:
         https://git.kerbcat.cn/KerbCat-CN/CKAN-Accelerator/issues
 


### PR DESCRIPTION
## Motivation

As of recently, a mod is giving users misleading directions about reporting bugs:

![image](https://github.com/KSP-CKAN/.github/assets/1559108/8c131bd1-6285-45a7-b9db-61dd8c1ad254)

Issues that are actually _related to CKAN_ should be reported to CKAN. Issues unrelated to CKAN should not.

## Changes

Now the CKAN bug report template has a note at the top pointing to the right place to report problems with TweakScale.
