### PR TITLE
remove note about tweakscale from bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/ckan_bug.yml
+++ b/.github/ISSUE_TEMPLATE/ckan_bug.yml
@@ -6,9 +6,6 @@ body:
   - type: markdown
     attributes:
       value: |
-        NOTE: Issues with TweakScale that do not relate to how mods are
-        installed should be reported on the TweakScale bug tracker here:
-        https://github.com/TweakScale/TweakScale/issues
         NOTE: If you are using the CKAN accelerator service in China, please report issues here instead:
         https://git.kerbcat.cn/KerbCat-CN/CKAN-Accelerator/issues
 


### PR DESCRIPTION
the whole spacedock tweakscale companion fiasco is over, we've come to a truce, and tweakscale-rescaled is probably going to make that confusing anyway.