### PR TITLE
Add links to the forum and Discord

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+contact_links:
+  - name: Discord
+    url: https://discord.gg/Mb4nXQD
+    about: Discord support server
+  - name: Forum
+    url: https://forum.kerbalspaceprogram.com/index.php?/topic/197082-*
+    about: KSP forum support thread


### PR DESCRIPTION
This will add links to the other support channels to the issue template list.

![image](https://github.com/KSP-CKAN/.github/assets/1559108/10b16939-8c94-4b2b-ab04-912546a78228)

- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser

Nice idea, @JonnyOThan.
