### PR TITLE
Provide links to the bug trackers

### DIFF
--- a/.github/ISSUE_TEMPLATE/ckan_bug.yml
+++ b/.github/ISSUE_TEMPLATE/ckan_bug.yml
@@ -14,8 +14,11 @@ body:
     attributes:
       label: Is there an existing issue for this?
       description: |
-        Please search to see if an issue already exists for the bug you encountered,
-        including closed issues in case it's something we have already investigated.
+        Please check the recent open and closed issues (especially the ones pinned to the top!)
+        to see if an issue already exists for the problem you encountered:
+        - <https://github.com/KSP-CKAN/CKAN/issues?q=is%3Aissue>
+        - <https://github.com/KSP-CKAN/NetKAN/issues?q=is%3Aissue>
+        - <https://github.com/KSP-CKAN/KSP2-NetKAN/issues?q=is%3Aissue>
       options:
         - label: I have searched the existing issues
           required: true


### PR DESCRIPTION
## Motivation

When KSP-CKAN/CKAN#4201 was submitted, KSP-CKAN/CKAN#4197 was still open and pinned to the top of the CKAN issues list, containing the exact text in its title that the submitter of the duplicate then typed:

![image](https://github.com/user-attachments/assets/389377c0-6219-42cf-a84e-698ecba094d9)

Clearly people sometimes do not check for duplicates and simply lie to that checkbox.
Maybe they don't know where to go to check for duplicates, and they decide that reporting the issue anyway is better than not.

## Changes

Now the template provides links to the bug trackers so users don't have to figure out where they're supposed to go to search for duplicates.
